### PR TITLE
Fix retrieval of BRCA1 and BRCA2 exon coordinates and specify exon and amplicon coordinates coordinate system

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ python bracnac.py -in file_with_coverage.csv -af file_with_coordinates.csv -out 
 ```
 BRACNAC can be used with graphical interface or in command-line version. As an input files both versions use:
 * Tab-separated file (TSV) with coverage for each target region (see the detailed description below).
-* TSV-file with coordinates for each target region. They should correspond to target regions of the coverage file.
+* TSV-file with coordinates for each target region. They should correspond to target regions of the coverage file. The coordinates should be 1-based and fully closed.
 
 *Other options and input files are optional.*
 ### Input file format
@@ -53,3 +53,6 @@ BRACNAC can be used with graphical interface or in command-line version. As an i
 * `-del2` Normalized value of coverage for considering an amplicon as probably deleted (default: 1.4)
 * `-dupl1` Normalized value of coverage for considering an amplicon as likely duplicated (default: 2.8)
 * `-dupl2` Normalized value of coverage for considering an amplicon as probably duplicated (default: 2.7)
+
+#### Note
+If you want to change exon coordinates in exon_coordinates.py, your exon coordinates should be 1-based and fully closed.

--- a/bracnac.py
+++ b/bracnac.py
@@ -55,7 +55,7 @@ class BRACNAC(QObject):
             print('ERROR! Reference genome can be only "hg19" or "hg38"')
             exit(1)
         # Getting CDS coordinates
-        brca1exons,brca2exons,posToExon1,posToExon2=getExonCoordinates()
+        brca1exons,brca2exons,posToExon1,posToExon2=getExonCoordinates(version=self.refVersion)
 
         # Getting patient table
         if self.patFile:

--- a/bracnac.py
+++ b/bracnac.py
@@ -89,6 +89,10 @@ class BRACNAC(QObject):
         lowCovAmplicons,maxi,maxj,colNames,sampleNames=inputData[3:8]
         dirName,outFilePart,minYs,maxYs,allValVars=inputData[8:]
 
+        # Create direcotry for output CNV tables
+        CNVTable_dirpath = f'{dirName}/CNV_tables'
+        os.makedirs(CNVTable_dirpath, exist_ok=True)
+
         # Create file for output
         wb,ws,f0,f1=createOutputFile(self.outFile,
                                      colNames,
@@ -140,7 +144,8 @@ class BRACNAC(QObject):
                                              exonToAmpls,
                                              amplToIntron,
                                              brca1AmpliconNum,
-                                             step,self)
+                                             step,self,
+                                             CNVTable_dirpath)
 
                     if step==1:
                         plotTitle,newCols,ampliconsColor=detectCnvOut

--- a/cnv_calling.py
+++ b/cnv_calling.py
@@ -5,6 +5,41 @@ import math
 import numpy as np
 import statistics as stat
 import itertools
+import pandas as pd
+
+def write_cnv_table(sample: str, cnv_lst: list, score_lst: list, pvalue_lst: list, CNVTable_dirpath: str):
+    """
+    Create a CNV table with CNVs from the output plot title.
+    """
+    # Round p-values
+    pvalue_lst = [round(float(pvalue), 3) for pvalue in pvalue_lst]
+    # Divide each CNV to CNV type, gene, and exon lists to create a data frame later
+    cnv_lst_lst = [cnv.split(',') for cnv in cnv_lst]
+    cnv_type_lst = []
+    gene_lst = []
+    exon_lst = []
+    for cnv_lst in cnv_lst_lst:
+        cnv_types = []
+        genes = []
+        exons = []
+        for cnv in cnv_lst:
+            cnv_type, gene, exon = cnv.split('_')
+            cnv_types.append(cnv_type)
+            genes.append(gene)
+            exons.append(exon)
+        same_cnv_type = len(set(cnv_types)) == 1
+        same_gene = len(set(genes)) == 1
+        if same_cnv_type and same_gene:
+            cnv_type_lst.append(cnv_types[0])
+            gene_lst.append(genes[0])
+            exon_lst.append('_'.join(exons))
+        else:
+            raise ValueError(f'Multiple non-consecutive exon CNV {cnv_lst} has either different CNV type, or gene, or both for different exons in sample {sample}.')
+    # Create a data frame
+    cnv_df = pd.DataFrame({'gene': gene_lst, 'cnv_type': cnv_type_lst, 'exon': exon_lst, 'score': score_lst, 'pvalue': pvalue_lst})
+    cnv_df = cnv_df.sort_values('gene')
+    CNVTable_filepath = f'{CNVTable_dirpath}/{sample}_CNV_BRACNAC.tsv'
+    cnv_df.to_csv(CNVTable_filepath, sep='\t', index=False)
 
 def detect_CNVs(data3,
                 sampleNum,
@@ -18,7 +53,8 @@ def detect_CNVs(data3,
                 exonToAmpls,
                 amplToIntron,
                 brca1AmpliconNum,
-                step,args):
+                step,args,
+                CNVTable_dirpath):
     if step==1:
         minScore=args.minScore
         maxPvalue=args.maxPvalue
@@ -395,6 +431,14 @@ def detect_CNVs(data3,
             text=sampleNames[sampleNum]+' ('+sampleIds[sampleNames[sampleNum].replace('patient_','')]+')\n'
         else:
             text=sampleNames[sampleNum]+'\n'
+        
+        # Create variables to write CNV table data to
+        sample = sampleNames[sampleNum]
+        cnv_lst = []
+        score_lst = []
+        pvalue_lst = []
+        # Create variables to write CNV table data to
+        
         if len(ads)>0:
             consideredExons=set()
             for delCNV in sorted(ads,
@@ -406,6 +450,15 @@ def detect_CNVs(data3,
                 text+='Deletion: '+delCNV+' (Score='+adsScores[ads.index(delCNV)]+', p-value='+adsValues[ads.index(delCNV)]+')\n'
                 consideredExons.update(set(range(bestAds[ads.index(delCNV)][0],
                                                  bestAds[ads.index(delCNV)][1]+1)))
+
+        # Uppend CNV data to lists
+        score = adsScores[ads.index(delCNV)]
+        pvalue = adsValues[ads.index(delCNV)]
+        cnv_lst.append(delCNV)
+        score_lst.append(score)
+        pvalue_lst.append(pvalue)
+        # Uppend CNV data to lists
+        
         else:
             text+='Deletions: No\n'
         if len(ais)>0:
@@ -419,8 +472,20 @@ def detect_CNVs(data3,
                 text+='Insertion: '+insCNV+' (Score='+aisScores[ais.index(insCNV)]+', p-value='+aisValues[ais.index(insCNV)]+')\n'
                 consideredExons.update(set(range(bestAis[ais.index(insCNV)][0],
                                                  bestAis[ais.index(insCNV)][1]+1)))
+
+        # Uppend CNV data to lists
+        score = aisScores[ais.index(insCNV)]
+        pvalue = aisValues[ais.index(insCNV)]
+        cnv_lst.append(insCNV)
+        score_lst.append(score)
+        pvalue_lst.append(pvalue)
+        # Uppend CNV data to lists
+        
         else:
             text+='Insertions: No'
+        
+        write_cnv_table(sample, cnv_lst, score_lst, pvalue_lst, CNVTable_dirpath)
+        
         return(text,newCols,ampliconsColor)
     else:
         return(obviousCnvSamples)

--- a/exon_coordinates.py
+++ b/exon_coordinates.py
@@ -23,8 +23,7 @@ def getExonCoordinates(version='hg19'):
     for ex in exons[version]:
         start,end=ex.split('..')
         brca1_exons.append([int(start),int(end)])
-    if version=='hg19':
-        brca1_exons=brca1_exons[::-1]
+    brca1_exons=brca1_exons[::-1]
     posToExon1={}
     for i,exon in enumerate(brca1_exons):
         for pos in range(exon[0],exon[1]+1):


### PR DESCRIPTION
**Add self.refVersion argument to getExonCoordinates() in bracnac.py**
In a bracnac.py there is a function getExonCoordinates that returns exon coordinates depending on the genome version passed: hg19 or hg38. Since no version was passed to the function in bracnac.py, the function always returned the exons in hg19, since it is a default to which the function switches when it does not get the version as an argument.

**Make BRCA1 exon order reversion uncoditional in getExonCoordinates() in exon_coordinates.py**
A function getExonCoordinates in exon_coordinates.py returns exons of BRCA1 and BRCA2 genes from hg19 or hg38 version of genome. BRCA1 is located on negative strand, so for the sake of intended exons representation on output plots, an order of BRCA1 exons is reversed, but only if genome version argument passed to the function is equal to hg19. But BRCA1 is located on negative strand in hg38 too, so I removed unnecessary condition.

**Specify coordinate system for amplicon and exon coordinates in README.md**
A line in the exon_coordinates.py where a cycle iterates through exon coordinates suggests that exon coordinates should be 1-based and fully closed. A line in the amplicon_file.py where a cycle iterates through amplicon coordinates suggests that amplicon coordinates should be 1-based and fully closed.